### PR TITLE
fix: 알바몬 api 수정

### DIFF
--- a/src/main/java/com/example/demo/albamon/controller/AlbamonController.java
+++ b/src/main/java/com/example/demo/albamon/controller/AlbamonController.java
@@ -3,9 +3,7 @@ package com.example.demo.albamon.controller;
 
 import com.example.demo.albamon.domain.Albamon;
 import com.example.demo.albamon.repository.AlbamonRepository;
-import lombok.Data;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
@@ -21,12 +19,23 @@ public class AlbamonController {
     private final AlbamonRepository albamonRepository;
 
     @GetMapping("/albamon")
-    public List<Albamon> getAlbamon(@RequestBody LoctionDto LocationDto) {
+    public List<Albamon> getAlbamon(@RequestBody List<LocationDto> LocationDtos) {
+        if (LocationDtos.size() != 2) {
+            throw new IllegalArgumentException("Exactly two coordinates are required to define a rectangle.");
+        }
+
+        LocationDto coord1 = LocationDtos.get(0);
+        LocationDto coord2 = LocationDtos.get(1);
+
+        double lat1 = Math.min(coord1.getLat(), coord2.getLat());
+        double lat2 = Math.max(coord1.getLat(), coord2.getLat());
+        double lng1 = Math.min(coord1.getLng(), coord2.getLng());
+        double lng2 = Math.max(coord1.getLng(), coord2.getLng());
 
 
         List<Albamon> albamons = albamonRepository
-                .findByLocationInRectangle(LocationDto.lat1, LocationDto.lng1,
-                        LocationDto.lat2, LocationDto.lng2);
+                .findByLocationInRectangle(lat1, lat2,
+                        lng1, lng2);
 
         /*
         List<AlbamonDto> albamonDtos = albamons.stream()
@@ -41,17 +50,12 @@ public class AlbamonController {
 
     @Data
     @Getter
-    public static class LoctionDto{
-        private double lat1;
-        private double lng1;
-        private double lat2;
-        private double lng2;
-        public LoctionDto(double lat1, double lng1, double lat2, double lng2) {
-            this.lat1 = lat1;
-            this.lng1 = lng1;
-            this.lat2 = lat2;
-            this.lng2 = lng2;
-        }
+    @AllArgsConstructor
+    public static class LocationDto{
+        private double lat;
+        private double lng;
+
+
     }
 
     @Data

--- a/src/main/java/com/example/demo/albamon/repository/AlbamonRepository.java
+++ b/src/main/java/com/example/demo/albamon/repository/AlbamonRepository.java
@@ -26,7 +26,7 @@ public interface AlbamonRepository extends JpaRepository<Albamon, Long> {
             "LIMIT 50", nativeQuery = true)
     List<Albamon> findByLocationInRectangle(
             @Param("lat1") double lat1,
-            @Param("lng1") double lng1,
             @Param("lat2") double lat2,
+            @Param("lng1") double lng1,
             @Param("lng2") double lng2);
 }


### PR DESCRIPTION
입력 형식은 [{"lat": 37, "lng": 127}, {"lat": 37, "lng": 127}] 으로 변경
로직: 두점을 기준으로 사각형 내부에 있는 알바몬 데이터를 출력